### PR TITLE
Fix issue with timemapItems

### DIFF
--- a/app/models/Book.js
+++ b/app/models/Book.js
@@ -76,7 +76,7 @@ define(['gv', 'models/Model', 'models/Places', 'models/Pages'],
                 items = [],
                 pages = book.pages,
                 startIndex = startId ? pages.indexOf(pages.get(startId)) : 0,
-                endIndex = endId ? pages.indexOf(pages.get(endId)) : pages.length - 1;
+                endIndex = endId ? pages.indexOf(pages.get(endId)) : pages.length;
             pages.models.slice(startIndex, endIndex)
                 .forEach(function(page) {
                     var places = _.uniq(page.get('places'));


### PR DESCRIPTION
According to Backbone, slice behave this way
> slicecollection.slice(begin, end)
> Return a shallow copy of this collection's models, using the same options as native Array#slice. 

It refers to [Mozilla doc](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice) which tells us

> Zero-based index at which to end extraction. slice extracts up to but not including end.

So the endIndex = pages.length so we include the last item